### PR TITLE
Test: checkoutLocalBranch should switch to new branch #HSFDPMUW

### DIFF
--- a/simple-git/test/unit/checkout-branch.spec.ts
+++ b/simple-git/test/unit/checkout-branch.spec.ts
@@ -1,0 +1,19 @@
+import { simpleGit } from '../../src';
+import { mkdtempSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+describe('checkoutLocalBranch', () => {
+  it('should create and switch to a new branch', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'git-branch-'));
+    const git = simpleGit(dir);
+
+    await git.init();
+    await git.commit('init', [], { '--allow-empty': null });
+
+    await git.checkoutLocalBranch('feature-branch');
+
+    const branch = await git.branch();
+    expect(branch.current).toBe('feature-branch');
+  });
+});


### PR DESCRIPTION
###  Inhalt
Dieser Pull Request enthält einen Unit-Test für die Methode `.checkoutLocalBranch()` von `simple-git`.

###  Details
- Erstellt ein temporäres Git-Repository
- Macht einen leeren Initial-Commit (`--allow-empty`)
- Erstellt und wechselt zu einem neuen Branch `feature-branch` mit `.checkoutLocalBranch()`
- Prüft, ob der aktuelle Branch korrekt gesetzt wurde

###  Erwartung
- Aktueller Branch ist `feature-branch`

###  Warum ist das nützlich?
- Testet typisches Branch-Management-Verhalten
- Verifiziert, dass `.checkoutLocalBranch()` wie dokumentiert funktioniert
- Trägt zur Testabdeckung und zur Robustheit der API bei

### Kontext
Dieser Beitrag erfolgt im Rahmen des Hochschulprojekts **#HSFDPMUW** – Modul: Programmiermethoden & Werkzeuge.