### PR TITLE
Test: log should return multiple commits from history #HSFDPMUW

### DIFF
--- a/simple-git/test/unit/log-history.spec.ts
+++ b/simple-git/test/unit/log-history.spec.ts
@@ -1,0 +1,29 @@
+import { writeFileSync, mkdtempSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { simpleGit } from '../../src';
+
+describe('log shows commit history', () => {
+  it('should show two commits', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'git-log-'));
+    const git = simpleGit(dir);
+
+    await git.init();
+
+    const file1 = join(dir, 'file1.txt');
+    writeFileSync(file1, 'first');
+    await git.add('file1.txt');
+    await git.commit('first commit');
+
+    const file2 = join(dir, 'file2.txt');
+    writeFileSync(file2, 'second');
+    await git.add('file2.txt');
+    await git.commit('second commit');
+
+    const log = await git.log();
+    expect(log.total).toBe(2);
+    expect(log.all.map(e => e.message)).toEqual(
+      expect.arrayContaining(['first commit', 'second commit'])
+    );
+  });
+});


### PR DESCRIPTION
###  Inhalt
Dieser Pull Request fügt einen Unit-Test für die Methode `.log()` von `simple-git` hinzu.

###  Details
- Erstellt ein temporäres Git-Repository
- Fügt zwei Dateien nacheinander hinzu (`file1.txt`, `file2.txt`)
- Führt jeweils einen Commit durch
- Ruft `.log()` auf und überprüft die Historie

###  Erwartung
- Git-Log gibt zwei Commits zurück
- Beide Commit-Messages sind enthalten (`first commit`, `second commit`)

###  Warum ist das nützlich?
- Testet ein zentrales Feature: die Historie der Commits
- Verifiziert das Verhalten von `.log()` mit mehreren Einträgen
- Unterstützt die langfristige Stabilität der API

### Kontext
Dieser Beitrag erfolgt im Rahmen des Hochschulprojekts **#HSFDPMUW** – Modul: Programmiermethoden & Werkzeuge.